### PR TITLE
Update tildagon.toml repo url

### DIFF
--- a/tildagon.toml
+++ b/tildagon.toml
@@ -28,7 +28,7 @@ author = "Merlin Howse"
 license = "LGPL-3.0-only"
 
 # URL to the repository of your app.
-url = "https://www.github.com/npentrel/tildagon-snake"
+url = "https://github.com/merlininthewoods/tildagon-bubble"
 
 # Description of your app.  Maximum 140 characters!
 description = "Simple spirit level aka bubble App"


### PR DESCRIPTION
Fix the repo url so its self-referential rather than pointing to another repo on https://apps.badge.emfcamp.org/apps/42032113/
Currently a bit confusing. I had to look up the app in https://github.com/topics/tildagon-app to find the correct repo